### PR TITLE
Fix go.uuid usage

### DIFF
--- a/commands/api/base.go
+++ b/commands/api/base.go
@@ -31,7 +31,8 @@ func (api *APIDef) setAPIDefinition() {
 
 func New(name string) *APIDef {
 	api := APIDef{}
-	api.id = strings.Replace(uuid.NewV4().String(), "-", "", -1)
+	id, _ := uuid.NewV4()
+	api.id = strings.Replace(id.String(), "-", "", -1)
 	api.name = name
 	return &api
 }


### PR DESCRIPTION
Got a report from @davegarvey about issues when running:
```
go get -u github.com/TykTechnologies/tyk-cli
```
Have found that our UUID library changed its syntax a bit, see [here](https://github.com/satori/go.uuid#example).
Also noticed that the default branch of this repository is `develop`, should we keep it this way?
Suggest we vendor the deps here too.
This is a quick fix to avoid breaking installs.